### PR TITLE
Fixed Sidekiq/Client to conform with more recent Sidekiq spe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "spinx/sidekiq-job-php",
+    "name": "hosportal/sidekiq-job-php",
     "description": "Push and schedule jobs to Sidekiq from PHP",
     "type": "library",
     "license": "MIT",

--- a/src/Client.php
+++ b/src/Client.php
@@ -127,9 +127,11 @@ class Client
      */
     private function atomicPush($jobId, $class, $args = [], $queue = self::QUEUE, $retry = true, $doAt = null)
     {
+        /* OUTDATED SIDEKIQ SPEC
         if (array_values($args) !== $args) {
             throw new Exception('Associative arrays in job args are not allowed');
         }
+        */
 
         if (!is_null($doAt) && !is_float($doAt) && is_string($doAt)) {
             throw new Exception('at argument needs to be in a unix epoch format. Use microtime(true).');


### PR DESCRIPTION
Associative arrays are now allowed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spinx/sidekiq-job-php/4)
<!-- Reviewable:end -->
