### PR TITLE
Raising JsonEncodeException when json_encode fails.

### DIFF
--- a/spec/SidekiqJob/SerializerSpec.php
+++ b/spec/SidekiqJob/SerializerSpec.php
@@ -4,6 +4,7 @@ namespace spec\SidekiqJob;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use SidekiqJob\JsonEncodeException;
 
 class SerializerSpec extends ObjectBehavior
 {
@@ -25,6 +26,14 @@ class SerializerSpec extends ObjectBehavior
     function is_throws_exception_if_not_valid_arguments()
     {
         $this->serialize([], true, false)->shouldThrowExeption();
+    }
+
+    function it_throws_exception_if_arguments_not_json_encodable()
+    {
+        $badJobArguments       = ['bad' => "\xc3\x28"];
+        $jobSerializeArguments = [1, new \stdClass(), $badJobArguments, true];
+
+        $this->shouldThrow(JsonEncodeException::class)->during('serialize', $jobSerializeArguments);
     }
 
     function it_returns_string(){

--- a/spec/SidekiqJob/SerializerSpec.php
+++ b/spec/SidekiqJob/SerializerSpec.php
@@ -30,7 +30,7 @@ class SerializerSpec extends ObjectBehavior
 
     function it_throws_exception_if_arguments_not_json_encodable()
     {
-        $badJobArguments       = ['bad' => "\xc3\x28"];
+        $badJobArguments = ['bad' => "\xc3\x28"];
         $jobSerializeArguments = [1, new \stdClass(), $badJobArguments, true];
 
         $this->shouldThrow(JsonEncodeException::class)->during('serialize', $jobSerializeArguments);

--- a/src/JsonEncodeException.php
+++ b/src/JsonEncodeException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SidekiqJob;
+
+/**
+ * @package SidekiqJob
+ */
+class JsonEncodeException extends \Exception
+{
+    /** @var mixed */
+    private $nonJsonEncodableData;
+    /** @var int */
+    private $jsonErrorCode;
+    /** @var string */
+    private $jsonErrorMessage;
+
+    /**
+     * @param string          $nonJsonEncodableData
+     * @param int             $jsonErrorCode
+     * @param string          $jsonErrorMessage
+     * @param \Exception|null $previous
+     */
+    public function __construct($nonJsonEncodableData, $jsonErrorCode, $jsonErrorMessage, \Exception $previous = null)
+    {
+        $this->nonJsonEncodableData = $nonJsonEncodableData;
+        $this->jsonErrorCode        = $jsonErrorCode;
+        $this->jsonErrorMessage     = $jsonErrorMessage;
+
+        parent::__construct(sprintf('Json encode error [%d]: %s', $jsonErrorCode, $jsonErrorMessage), 0, $previous);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNonJsonEncodableData()
+    {
+        return $this->nonJsonEncodableData;
+    }
+}

--- a/src/JsonEncodeException.php
+++ b/src/JsonEncodeException.php
@@ -23,8 +23,8 @@ class JsonEncodeException extends \Exception
     public function __construct($nonJsonEncodableData, $jsonErrorCode, $jsonErrorMessage, \Exception $previous = null)
     {
         $this->nonJsonEncodableData = $nonJsonEncodableData;
-        $this->jsonErrorCode        = $jsonErrorCode;
-        $this->jsonErrorMessage     = $jsonErrorMessage;
+        $this->jsonErrorCode = $jsonErrorCode;
+        $this->jsonErrorMessage = $jsonErrorMessage;
 
         parent::__construct(sprintf('Json encode error [%d]: %s', $jsonErrorCode, $jsonErrorMessage), 0, $previous);
     }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -24,12 +24,12 @@ class Serializer
         $class = is_object($class) ? get_class($class) : $class;
 
         $data = [
-            'class'       => $class,
-            'jid'         => $jobId,
-            'created_at'  => microtime(true),
+            'class' => $class,
+            'jid' => $jobId,
+            'created_at' => microtime(true),
             'enqueued_at' => microtime(true),
-            'args'        => $args,
-            'retry'       => $retry,
+            'args' => $args,
+            'retry' => $retry,
         ];
 
         $jsonEncodedData = json_encode($data);

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -14,23 +14,31 @@ class Serializer
      * @param string        $jobId
      * @param object|string $class
      * @param array         $args
+     * @param bool          $retry
+     *
      * @return string
-     * @throws exception Exception
+     * @throws JsonEncodeException
      */
     public function serialize($jobId, $class, $args = [], $retry = true)
     {
         $class = is_object($class) ? get_class($class) : $class;
 
         $data = [
-            'class' => $class,
-            'jid' => $jobId,
-            'created_at' => microtime(true),
+            'class'       => $class,
+            'jid'         => $jobId,
+            'created_at'  => microtime(true),
             'enqueued_at' => microtime(true),
-            'args' => $args,
-            'retry' => $retry,
+            'args'        => $args,
+            'retry'       => $retry,
         ];
 
-        return json_encode($data);
+        $jsonEncodedData = json_encode($data);
+
+        if ($jsonEncodedData === false) {
+            throw new JsonEncodeException($data, json_last_error(), json_last_error_msg());
+        }
+
+        return $jsonEncodedData;
     }
 
     /**


### PR DESCRIPTION
Issue:

`Serializer` does not fail if job argument cannot be encoded to JSON properly. 
This results in `Serializer::serialize` to return `false`. 
Redis driver interpolates `false` into string as an empty string `""`, which results in an empty task inside redis.

Solution:

We detect when `json_encode` returns `false` and raise an exception in that case. The exception includes the malformed data which can then be inspected/logged on demand by the application itself.